### PR TITLE
Fix emoji usage when tallying reactions

### DIFF
--- a/commands/EndPoll.js
+++ b/commands/EndPoll.js
@@ -39,7 +39,7 @@ module.exports = {
     const result = embed.description.split('\n').map(field => {
         const emoji = field.split(' ')[0];
         const choice = field.split(' ')[1];
-        const reaction = reactions.find(reaction => reaction._emoji.name === emoji);
+        const reaction = reactions.find(r => r.emoji && r.emoji.name === emoji);
         const count = reaction ? reaction.count : 0; // 自分自身のリアクションを除外
         return { emoji, choice, count };
       });

--- a/commands/StartPoll.js
+++ b/commands/StartPoll.js
@@ -106,7 +106,7 @@ module.exports = {
         const result = embed.description.split('\n').map(field => {
             const emoji = field.split(' ')[0];
             const choice = field.split(' ')[1];
-            const reaction = reactions.find(reaction => reaction._emoji.name === emoji);
+            const reaction = reactions.find(r => r.emoji && r.emoji.name === emoji);
             const count = reaction ? reaction.count : 0; // 自分自身のリアクションを除外
             return { emoji, choice, count };
           });


### PR DESCRIPTION
## Summary
- fix polling emoji check to use `reaction.emoji.name`

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_683fa403a868832e9e4616eb04fbab7f